### PR TITLE
Remove receive() so all calls go through fallback()

### DIFF
--- a/src/L2Proxy.sol
+++ b/src/L2Proxy.sol
@@ -114,8 +114,8 @@ contract L2Proxy {
         }
     }
 
-    /// @notice Allows the proxy to receive ETH
-    receive() external payable {}
+    // NOTE: No receive() function - all calls (including plain ETH transfers) go to fallback()
+    // This ensures the bridging logic is always triggered.
 
     /// @notice Executes a call on behalf of another authorized proxy
     /// @dev Only callable by the Rollups contract or other authorized proxies


### PR DESCRIPTION
When sending ETH to an L2Proxy with empty calldata, Solidity routes to receive() instead of fallback(). The previous receive() function did nothing, causing ETH to be stuck in the proxy on L1.

The simplest fix is to remove receive() entirely. With only a payable fallback(), all calls (with or without calldata) go to fallback(), ensuring the bridging logic is always triggered.